### PR TITLE
support for illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ documentation = "https://docs.rs/pipe-channel/"
 repository = "https://github.com/bugaevc/pipe-channel"
 
 [dependencies]
-nix = "0.17.0"
+nix = "0.23.1"
 libc = "0.2.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipe-channel"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2018"
 authors = ["Sergey Bugaev <bugaevc@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ impl<T> Sender<T> {
         while n < s.len() {
             match nix::unistd::write(self.fd, &s[n..]) {
                 Ok(count) => n += count,
-                Err(nix::Error::Sys(nix::errno::Errno::EPIPE)) => return Err(SendError(t)),
+                Err(nix::errno::Errno::EPIPE) => return Err(SendError(t)),
                 e => { e.unwrap(); }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,17 +509,24 @@ mod tests {
 
     #[test]
     fn large_data() {
-        struct Large([usize; 4096]);
+        // on at least illumos systems, the larger write blocks waiting for a
+        // reader:
+        #[cfg(target_os = "illumos")]
+        const LARGE_SIZE: usize = 2048;
+        #[cfg(not(target_os = "illumos"))]
+        const LARGE_SIZE: usize = 4096;
+
+        struct Large([usize; LARGE_SIZE]);
         impl Large {
             fn new() -> Large {
-                let mut res = [0; 4096];
+                let mut res = [0; LARGE_SIZE];
                 for i in 0..(res.len()) {
                     res[i] = i * i;
                 }
                 Large(res)
             }
         }
-        unsafe impl Send for Large {};
+        unsafe impl Send for Large {}
 
         // may want to use threads, as it may block
         let (mut tx, mut rx) = channel();


### PR DESCRIPTION
I was trying to use something that transitively uses pipe-channel, and discovered that it doesn't build today on illumos.  Fortunately a nix update was all that was required, which I have done here.  I also fixed the tests on an illumos system:

```
$ cargo test --lib
   Compiling pipe-channel v1.3.1 (/ws/safari/pipe-channel)
    Finished test [unoptimized + debuginfo] target(s) in 1m 15s
     Running unittests (target/debug/deps/pipe_channel-e2a9b49cb621c3d3)

running 8 tests
test tests::zero_sized_type_drop ... ok
test tests::no_send_no_threading ... ok
test tests::raw_fd ... ok
test tests::no_drop_on_recv_err ... ok
test tests::debug_print ... ok
test tests::zero_sized_type ... ok
test tests::no_leak ... ok
test tests::large_data ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ uname -a
SunOS sigma 5.11 joyent_20220127T011500Z i86pc i386 i86pc
```